### PR TITLE
Add simple config screen

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,12 +1,11 @@
 // initialization
 const config = {
-    classList: [] /*readConfig("classList", "")
+    classList: readConfig("classList", "")
         .toLowerCase()
-        .split("\n")
-        .map((s) => s.trim())*/,
-    allowMode: true, //readConfig("allowMode", true),
-    denyMode: false, //readConfig("denyMode", false),
-    debugMode: true, //readConfig("debugMode", true)
+        .split(",")
+        .map((s) => s.trim()),
+    allowMode: readConfig("allowMode", false),
+    debugMode: false
 };
 
 function debug(...args) {
@@ -29,7 +28,7 @@ workspace.windowAdded.connect(window => {
     // abort conditions
     if (!window // null
         || (config.allowMode && config.classList.includes(String(window.resourceClass))) // using allowmode and window class is in list
-        || (config.denyMode && !config.classList.includes(String(window.resourceClass))) // using denymode and window class is not in list
+        || (!config.allowMode && !config.classList.includes(String(window.resourceClass))) // using denymode and window class is not in list
         || !(window.resizeable && window.moveable && window.moveableAcrossScreens) // not regeomtrizable
         || window.screen == activeScreen) // already on right screen
         return;

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0
+      http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
+    <kcfgfile name=""/>
+    <group name="">
+        <entry name="classList" type="string">
+            <default></default>
+        </entry>
+        <entry name="allowMode" type="bool">
+            <default>false</default>
+        </entry>
+    </group>
+</kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OpenWindowOnActiveScreenConfig</class>
+ <widget class="QWidget" name="OpenWindowOnActiveScreenConfig">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Open Windows on Active Screen</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_classList">
+     <property name="text">
+      <string>List of classes to exclude (comma separated)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLineEdit" name="kcfg_classList">
+      <property name="text">
+        <string></string>
+      </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QCheckBox" name="kcfg_allowMode">
+      <property name="text">
+        <string>Allow class names in list, rather than exclude</string>
+      </property>
+      <property name="checked">
+        <bool>false</bool>
+      </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Hi :3 I really love your custom script and find it useful in migrating to Plasma 6 from 5. I wanted to be able to exclude certain window classes. I noticed your script had this functionality already, but lacked a way to enable it short of editing the config dict in `main.js` manually.

So, I made a simple menu for your script accessible from the KWin Scripts menu! I had to merge `allowMode` and `denyMode` into one checkbox, but since they were effectively already a boolean, I think it's fine.

![2024_12_02_00-33-25](https://github.com/user-attachments/assets/34c1cec6-2fca-49e5-a4e6-dc59b2276901)